### PR TITLE
Fix typo in parse_identifier docstring

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -123,7 +123,7 @@ class Parser:
     # ───────────────────────── expressions ─────────────────────────
 
     def parse_identifier(self) -> Expr:
-        """Parse a single indentifier like: x, foo, my_var
+        """Parse a single identifier like: x, foo, my_var
         
         Grammar fragment: Identifier ::= <IDENTIFIER>
         AST target: Indentifier(name)


### PR DESCRIPTION
## Summary
- fix `parse_identifier` docstring typo

## Testing
- `pytest -q` *(fails: SyntaxError in type_checker.py)*

------
https://chatgpt.com/codex/tasks/task_e_6851d35748608321b999f49fff243c2c