### PR TITLE
Fix elapsed decorator and clean file ending

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,12 @@
 import time
 from functools import wraps
 
-@wraps
 def elapsed(func):
+    @wraps(func)
     def wrapper(*args, **kwargs):
         start = time.perf_counter()
-        func(*args, **kwargs)
-        elapsed = time.perf_counter() - start
-        print(f"[info] Elapsed time for {func.__name__}: {elapsed*1000:.2f} ms")
-        return func
+        result = func(*args, **kwargs)
+        elapsed_time = time.perf_counter() - start
+        print(f"[info] Elapsed time for {func.__name__}: {elapsed_time*1000:.2f} ms")
+        return result
     return wrapper


### PR DESCRIPTION
## Summary
- fix `elapsed` decorator to use `@wraps(func)` and return function result
- ensure `utils.py` ends without leftover prompt text

## Testing
- `pytest -q` *(fails: SyntaxError in src/type_checker.py)*

------
https://chatgpt.com/codex/tasks/task_e_6851d4269afc8321b30274f3e76ad733