### PR TITLE
Update runtime ref test and minor fixes

### DIFF
--- a/ref/lang_expected_output.out
+++ b/ref/lang_expected_output.out
@@ -1,0 +1,105 @@
+=== Import and Call ===
+Runinng helper from imported utils.pb file
+=== F-String Interpolation ===
+Value is 42
+Hello, Alice!
+=== Global Variable Before Update ===
+100
+=== Global Variable After Update ===
+200
+=== Function Call ===
+Adding numbers:
+15
+=== Function with Default Argument ===
+6
+8
+=== Assert Statement ===
+Assertion passed
+=== Handle Float/Double ===
+50.000000
+=== If/Else ===
+Total is odd
+=== While Loop ===
+0
+1
+2
+=== For Loop with range(0, 3) ===
+0
+1
+2
+=== For Loop with range(2) ===
+0
+1
+=== Break and Continue ===
+0
+1
+3
+=== List and Indexing ===
+100
+100
+[100, 200, 300]
+1.100000
+[1.1, 2.2, 3.3]
+abc
+["abc", "def"]
+True
+[true, false]
+[100.101, 2.2, 3.3]
+["some string", "def"]
+[false, false]
+=== List Operations ===
+=== Dict Literal and Access ===
+10
+75
+sth here
+and here
+=== Try / Except / Raise ===
+=== Boolean Literals ===
+x is True and y is False
+=== If/Elif/Else ===
+five
+=== Pass Statement ===
+Pass block completed
+=== Is / Is Not Operators ===
+a is b
+a is not 20
+=== Augmented Assignment ===
+5
+8
+6
+24
+12
+0
+2.500000
+=== Explicit Type Conversion ===
+i: 10, f: 10.000000
+f2: 3.500000, i2: 3
+=== Class Instantiation and Methods ===
+player.hp: 110
+Healing player by 50...
+160
+Adding player's hp to global counter...
+Updated counter:
+360
+=== Class vs Instance Variables ===
+Player1 score: 100
+Player2 score (should be default): 0
+Player class species: Human
+Species from player1 (via class attribute): Human
+Player1.hp (instance attribute): 777
+Player2.hp (instance attribute): 5678
+Player.hp (class attribute): 100
+Directly setting player.hp to 999
+999
+=== Inheritance: Mage Subclass ===
+Mage name: Hero
+Mage HP: 120
+Mage MP: 200
+Mage casts a spell costing 20 mana...
+Spell cast!
+Remaining MP: 180
+Mage takes damage and heals...
+HP after damage: 90
+MP after damage: 170
+HP after healing: 130
+MP after healing: 190

--- a/ref/ref_lang.c
+++ b/ref/ref_lang.c
@@ -1,4 +1,5 @@
 #include "lang.h"
+#include "utils.h"
 int64_t counter = 100;
 int64_t Player_hp = 100;
 const char * Player_species = "Human";
@@ -135,6 +136,8 @@ int main(void)
 {
     char __fbuf[256];
     (void)__fbuf;
+    pb_print_str("=== Import and Call ===");
+    utils_helper();
     pb_print_str("=== F-String Interpolation ===");
     int64_t value = 42;
     const char * name = "Alice";

--- a/ref/ref_lang.h
+++ b/ref/ref_lang.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "pb_runtime.h"
+#include "utils.h"
 extern int64_t counter;
 typedef struct Player {
     int64_t hp;

--- a/src/codegen.py
+++ b/src/codegen.py
@@ -864,7 +864,7 @@ class CodeGen:
             for stmt in getattr(self._program, "body", []):
                 if isinstance(stmt, ImportStmt):
                     if hasattr(stmt, "module") and stmt.module[0] in self._modules:
-                        if fn_name not in self._function_params:
+                        if mangled not in self._function_params:
                             imported_from = stmt.module[0]
                     if hasattr(stmt, "names") and fn_name in getattr(stmt, "names", []):
                         imported_from = stmt.module[0]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,8 +9,8 @@ from pb_pipeline import compile_code_to_ast, compile_code_to_c_and_h
 BASE_DIR = os.path.dirname(__file__)
 
 class TestCodeGenFromSource(unittest.TestCase):
-    def compile_pipeline(self, code: str) -> tuple:
-        h, c, *_ = compile_code_to_c_and_h(code)
+    def compile_pipeline(self, code: str, pb_path: str | None = None) -> tuple:
+        h, c, *_ = compile_code_to_c_and_h(code, pb_path=pb_path)
         return h, c
 
     # ────────────────────────────────────────────────────────────────
@@ -29,7 +29,11 @@ class TestCodeGenFromSource(unittest.TestCase):
         with open(expected_c_path) as f:
             expected_c = f.read()
 
-        generated_h, generated_c, *_ = compile_code_to_c_and_h(source, module_name="lang")
+        generated_h, generated_c, *_ = compile_code_to_c_and_h(
+            source,
+            module_name="lang",
+            pb_path=pb_path,
+        )
 
         # Optional: normalize line endings to be OS-independent
         expected_h_normalized = expected_h.replace("\r\n", "\n").strip()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -383,6 +383,23 @@ class TestPipelineRuntime(unittest.TestCase):
         self.assertEqual(lines[2], "3.141500")
 
 
+class TestRefLangOutput(unittest.TestCase):
+    """Runtime test for the reference program."""
+
+    def test_ref_lang_runtime_output(self):
+        base = os.path.join(os.path.dirname(__file__), "..", "ref")
+        with open(os.path.join(base, "lang.pb")) as f:
+            lang_src = f.read()
+        with open(os.path.join(base, "utils.pb")) as f:
+            utils_src = f.read()
+        with open(os.path.join(base, "lang_expected_output.out")) as f:
+            expected_lines = f.read().splitlines()
+
+        output = _compile_and_run_modules({"lang": lang_src, "utils": utils_src})
+        self.assertEqual(output.splitlines(), expected_lines)
+
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure reference header and source files end with newline
- simplify imported function detection in codegen
- add full runtime output check for reference program
- store reference program output in `lang_expected_output.out`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857db588800832184cf97b5f6192d97