### PR TITLE
Implement finally and re-raise

### DIFF
--- a/ref/lang_expected_output.out
+++ b/ref/lang_expected_output.out
@@ -54,6 +54,7 @@ True
 sth here
 and here
 === Try / Except / Raise ===
+Caught division by zero
 === Boolean Literals ===
 x is True and y is False
 === If/Elif/Else ===

--- a/ref/ref_lang.c
+++ b/ref/ref_lang.c
@@ -108,7 +108,7 @@ int64_t lang_divide(int64_t x, int64_t y)
     char __fbuf[256];
     (void)__fbuf;
     if ((y == 0)) {
-        pb_fail("Exception raised");
+        pb_raise("RuntimeError", "division by zero");
     }
     return (x / y);
 }
@@ -238,7 +238,25 @@ int main(void)
     pb_print_str(pb_dict_get_str_str(map_str, "a"));
     pb_print_str(pb_dict_get_str_str(map_str, "b"));
     pb_print_str("=== Try / Except / Raise ===");
-    /* try/except not supported at runtime */
+    PbTryContext __exc_ctx_1;
+    pb_push_try(&__exc_ctx_1);
+    int __exc_flag_1 = setjmp(__exc_ctx_1.env);
+    bool __exc_handled_1 = false;
+    if (__exc_flag_1 == 0) {
+        int64_t result = lang_divide(10, 0);
+        pb_print_int(result);
+    pb_pop_try();
+    } else {
+        if (strcmp(pb_current_exc.type, "RuntimeError") == 0) {
+            pb_print_str("Caught division by zero");
+            pb_clear_exc();
+            __exc_handled_1 = true;
+        }
+        else {
+            pb_reraise();
+        }
+    }
+    if (__exc_flag_1 && !__exc_handled_1) pb_reraise();
     pb_print_str("=== Boolean Literals ===");
     bool x = true;
     bool y = false;
@@ -294,9 +312,9 @@ int main(void)
     int64_t i2 = (int64_t)(f2);
     pb_print_str((snprintf(__fbuf, 256, "f2: %f, i2: %lld", f2, i2), __fbuf));
     pb_print_str("=== Class Instantiation and Methods ===");
-    struct Player __tmp_player_1;
-    Player____init__(&__tmp_player_1, 110, 150);
-    struct Player * player = &__tmp_player_1;
+    struct Player __tmp_player_2;
+    Player____init__(&__tmp_player_2, 110, 150);
+    struct Player * player = &__tmp_player_2;
     pb_print_str((snprintf(__fbuf, 256, "player.hp: %lld", player->hp), __fbuf));
     pb_print_str("Healing player by 50...");
     Player__heal(player, 50);
@@ -306,12 +324,12 @@ int main(void)
     pb_print_str("Updated counter:");
     pb_print_int(counter);
     pb_print_str("=== Class vs Instance Variables ===");
-    struct Player __tmp_player_2;
-    Player____init__(&__tmp_player_2, 1234, 150);
-    struct Player * player1 = &__tmp_player_2;
     struct Player __tmp_player_3;
-    Player____init__(&__tmp_player_3, 5678, 150);
-    struct Player * player2 = &__tmp_player_3;
+    Player____init__(&__tmp_player_3, 1234, 150);
+    struct Player * player1 = &__tmp_player_3;
+    struct Player __tmp_player_4;
+    Player____init__(&__tmp_player_4, 5678, 150);
+    struct Player * player2 = &__tmp_player_4;
     player1->score = 100;
     pb_print_str((snprintf(__fbuf, 256, "Player1 score: %lld", player1->score), __fbuf));
     pb_print_str((snprintf(__fbuf, 256, "Player2 score (should be default): %lld", player2->score), __fbuf));
@@ -325,9 +343,9 @@ int main(void)
     player->hp = 999;
     pb_print_int(player->hp);
     pb_print_str("=== Inheritance: Mage Subclass ===");
-    struct Mage __tmp_mage_4;
-    Mage____init__(&__tmp_mage_4, 120);
-    struct Mage * mage = &__tmp_mage_4;
+    struct Mage __tmp_mage_5;
+    Mage____init__(&__tmp_mage_5, 120);
+    struct Mage * mage = &__tmp_mage_5;
     pb_print_str((snprintf(__fbuf, 256, "Mage name: %s", Mage__get_name(mage)), __fbuf));
     pb_print_str((snprintf(__fbuf, 256, "Mage HP: %lld", mage->base.hp), __fbuf));
     pb_print_str((snprintf(__fbuf, 256, "Mage MP: %lld", mage->mp), __fbuf));

--- a/src/lang_ast.py
+++ b/src/lang_ast.py
@@ -109,6 +109,7 @@ class ForStmt:
 class TryExceptStmt:
     try_body: List[Stmt]
     except_blocks: List[ExceptBlock]
+    finally_body: Optional[List[Stmt]] = None
 
 
 @dataclass
@@ -120,7 +121,7 @@ class ExceptBlock:
 
 @dataclass
 class RaiseStmt:
-    exception: Expr
+    exception: Optional[Expr]
 
 
 @dataclass

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -13,7 +13,7 @@ class TokenType(Enum):
     AND = auto(); OR = auto(); BREAK = auto(); CONTINUE = auto(); PASS = auto()
     GLOBAL = auto(); IMPORT = auto(); CLASS = auto(); ASSERT = auto()
     TRUE = auto(); FALSE = auto(); NONE = auto()
-    TRY = auto(); EXCEPT = auto(); RAISE = auto(); AS = auto()
+    TRY = auto(); EXCEPT = auto(); FINALLY = auto(); RAISE = auto(); AS = auto()
 
     # Symbols
     COLON = auto(); COMMA = auto(); LPAREN = auto(); RPAREN = auto()
@@ -93,6 +93,7 @@ KEYWORDS = {
     "or": TokenType.OR,
     "try": TokenType.TRY,
     "except": TokenType.EXCEPT,
+    "finally": TokenType.FINALLY,
     "as": TokenType.AS,
     "raise": TokenType.RAISE,
     "True": TokenType.TRUE,

--- a/src/parser.py
+++ b/src/parser.py
@@ -971,11 +971,13 @@ class Parser:
         """Parse a raise statement
 
         Grammar:
-        RaiseStmt ::= "raise" Expr NEWLINE
-        AST: RaiseStmt(exception)
+        RaiseStmt ::= "raise" [Expr] NEWLINE
+        AST: RaiseStmt(exception_or_none)
         """
         self.expect(TokenType.RAISE)
-        expr = self.parse_expr()
+        expr = None
+        if not self.check(TokenType.NEWLINE):
+            expr = self.parse_expr()
         self.expect(TokenType.NEWLINE)
         return RaiseStmt(expr)
 
@@ -985,7 +987,8 @@ class Parser:
         Grammar:
         TryExceptStmt ::= "try" ":" NEWLINE INDENT { Statement } DEDENT
                           { "except" [Identifier] [ "as" Identifier ] ":" NEWLINE INDENT { Statement } DEDENT }
-        AST: TryExceptStmt(try_body, except_blocks)
+                          [ "finally" ":" NEWLINE INDENT { Statement } DEDENT ]
+        AST: TryExceptStmt(try_body, except_blocks, finally_body?)
         """
         self.expect(TokenType.TRY)
         self.expect(TokenType.COLON)
@@ -1020,7 +1023,17 @@ class Parser:
 
             except_blocks.append(ExceptBlock(exc_type, alias, body))
 
-        return TryExceptStmt(try_body, except_blocks)
+        finally_body: Optional[List[Stmt]] = None
+
+        if self.match(TokenType.FINALLY):
+            self.expect(TokenType.COLON)
+            self.expect(TokenType.NEWLINE)
+            self.expect(TokenType.INDENT)
+            finally_body = []
+            while not self.match(TokenType.DEDENT):
+                finally_body.append(self.parse_statement())
+
+        return TryExceptStmt(try_body, except_blocks, finally_body)
 
     def parse_import_stmt(self) -> ImportStmt:
         """Parse an import statement

--- a/src/pb_runtime.h
+++ b/src/pb_runtime.h
@@ -19,6 +19,30 @@ void pb_print_bool(bool b);
 
 void pb_fail(const char *msg);
 
+/* ------------ EXCEPTIONS ------------- */
+
+#include <setjmp.h>
+#include <assert.h>
+
+typedef struct {
+    const char *type;
+    void *value;
+} PbException;
+
+typedef struct PbTryContext {
+    jmp_buf env;
+    struct PbTryContext *prev;
+} PbTryContext;
+
+extern PbTryContext *pb_current_try;
+extern PbException pb_current_exc;
+
+void pb_push_try(PbTryContext *ctx);
+void pb_pop_try(void);
+void pb_raise(const char *type, void *value);
+void pb_clear_exc(void);
+void pb_reraise(void);
+
 /* ------------ LIST ------------- */
 typedef struct {
     int64_t len;

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -1258,13 +1258,13 @@ class TypeChecker:
             raise TypeError(f"Assert expression must be bool, got {cond_type}")
 
     def check_raise_stmt(self, stmt: RaiseStmt):
-        """Check that raise expression is not None.
-
-        For now, accept any non-None value, and reject None
-        """
-        exc_type = self.check_expr(stmt.exception)
-        if exc_type == "None":
-            raise TypeError(f"Cannot raise value of type None — expression was: {stmt.exception}")
+        """Check a raise statement."""
+        if stmt.exception is not None:
+            exc_type = self.check_expr(stmt.exception)
+            if exc_type == "None":
+                raise TypeError(
+                    f"Cannot raise value of type None — expression was: {stmt.exception}"
+                )
 
     def check_global_stmt(self, stmt: GlobalStmt):
         """Ensure global declaration is inside a function body.
@@ -1283,7 +1283,7 @@ class TypeChecker:
             self.env[name] = self.global_env[name]
 
     def check_try_except_stmt(self, stmt: TryExceptStmt):
-        """Type-check try-except blocks."""
+        """Type-check try/except/finally blocks."""
         # Check try block
         for s in stmt.try_body:
             self.check_stmt(s)
@@ -1304,6 +1304,10 @@ class TypeChecker:
                 self.check_stmt(s)
 
             self.env = old_env
+
+        if stmt.finally_body:
+            for s in stmt.finally_body:
+                self.check_stmt(s)
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -566,10 +566,11 @@ class TestCodeGen(unittest.TestCase):
             )
         ])
         output = codegen_output(program)
-        assert_contains_all(self, output, [
-            "/* try/except not supported at runtime */",
-            "return 0;"
-        ])
+        self.assertIn('pb_push_try(&', output)
+        self.assertIn('pb_raise("RuntimeError"', output)
+        self.assertIn('strcmp(pb_current_exc.type, "RuntimeError") == 0', output)
+        self.assertIn('pb_clear_exc();', output)
+        self.assertIn('pb_reraise();', output)
 
     def test_global_variable_in_method(self):
         program = Program(body=[

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -494,9 +494,9 @@ class TestCodeGenFromSource(unittest.TestCase):
             "    crash()\n"
         )
         header, c_code = self.compile_pipeline(pb_code)
-        # Should emit the constructor forwarding and fail call
+        # Should emit the constructor forwarding and raise call
         self.assertIn('Exception____init__((struct Exception *)self, msg);', c_code)
-        self.assertIn('pb_fail("Exception raised");', c_code)
+        self.assertIn('pb_raise("RuntimeError"', c_code)
         # Should use the forwarded RuntimeError constructor
         self.assertIn('void RuntimeError____init__(struct RuntimeError * self, const char * msg)', c_code)
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -288,7 +288,42 @@ class TestPipelineRuntime(unittest.TestCase):
             "    crash()\n"
         )
         output = compile_and_run(code)
-        self.assertIn("Exception raised", output)
+        self.assertIn("Uncaught RuntimeError", output)
+
+    def test_reraise(self):
+        code = (
+            "class Exception:\n"
+            "    def __init__(self, msg: str):\n"
+            "        self.msg = msg\n"
+            "\n"
+            "class MyError(Exception):\n"
+            "    pass\n"
+            "\n"
+            "def foo():\n"
+            "    try:\n"
+            "        raise MyError('oops')\n"
+            "    except:\n"
+            "        raise\n"
+            "\n"
+            "def main():\n"
+            "    try:\n"
+            "        foo()\n"
+            "    except MyError as e:\n"
+            "        print(e.msg)\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "oops")
+
+    def test_finally_runs(self):
+        code = (
+            "def main():\n"
+            "    try:\n"
+            "        print('A')\n"
+            "    finally:\n"
+            "        print('B')\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip().splitlines(), ['A', 'B'])
 
     def test_default_arguments(self):
         code = (


### PR DESCRIPTION
## Summary
- extend AST and parser for finally blocks and bare raise
- add pb_clear_exc and pb_reraise to runtime
- generate proper try/except/finally C code with re-raise
- update reference output
- add tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857fe4773b0832185a8fedbe0bfe80a