### PR TITLE
Add file IO support

### DIFF
--- a/src/pb_runtime.c
+++ b/src/pb_runtime.c
@@ -167,6 +167,40 @@ void pb_reraise(void) {
     pb_raise_obj(pb_current_exc.type, pb_current_exc.value);
 }
 
+/* ------------ FILE ------------- */
+
+PbFile pb_open(const char *path, const char *mode) {
+    FILE *fp = fopen(path, mode);
+    if (!fp) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "Failed to open file %s", path);
+        pb_fail(buf);
+    }
+    PbFile f = {fp};
+    return f;
+}
+
+const char *pb_file_read(PbFile f) {
+    fseek(f.handle, 0, SEEK_END);
+    long size = ftell(f.handle);
+    fseek(f.handle, 0, SEEK_SET);
+    char *buf = malloc(size + 1);
+    if (!buf) pb_fail("Out of memory in pb_file_read");
+    size_t n = fread(buf, 1, size, f.handle);
+    buf[n] = '\0';
+    return buf;
+}
+
+void pb_file_write(PbFile f, const char *s) {
+    if (fputs(s, f.handle) == EOF) {
+        pb_fail("Failed to write file");
+    }
+}
+
+void pb_file_close(PbFile f) {
+    fclose(f.handle);
+}
+
 void pb_index_error(const char *type, const char *op, int64_t index, int64_t len, void *ptr) {
     char buf[256];
     if (strcmp(op, "get") == 0) {

--- a/src/pb_runtime.h
+++ b/src/pb_runtime.h
@@ -54,6 +54,17 @@ void pb_raise_obj(const char *type, void *obj);
 void pb_clear_exc(void);
 void pb_reraise(void);
 
+/* ------------ FILE ------------- */
+
+typedef struct {
+    FILE *handle;
+} PbFile;
+
+PbFile pb_open(const char *path, const char *mode);
+const char *pb_file_read(PbFile f);
+void pb_file_write(PbFile f, const char *s);
+void pb_file_close(PbFile f);
+
 /* ------------ LIST ------------- */
 typedef struct {
     int64_t len;

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -428,6 +428,21 @@ class TestPipelineRuntime(unittest.TestCase):
         self.assertEqual(lines[1], "9")
         self.assertEqual(lines[2], "3.1415")
 
+    def test_file_read_write(self):
+        code = (
+            "def main() -> int:\n"
+            "    f: file = open('tmp.txt', 'w')\n"
+            "    f.write('Hello!')\n"
+            "    f.close()\n"
+            "    f = open('tmp.txt', 'r')\n"
+            "    data: str = f.read()\n"
+            "    f.close()\n"
+            "    print(data)\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "Hello!")
+
 
 class TestRefLangOutput(unittest.TestCase):
     """Runtime test for the reference program."""

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -2529,3 +2529,11 @@ class TestTypeCheckerProgramLevel(unittest.TestCase):
         checker = TypeChecker().check(prog)
         self.assertEqual(checker.body[0].inferred_type, "list[bool]")
         self.assertEqual(checker.body[1].inferred_type, "list[bool]")
+
+    def test_open_and_file_methods(self):
+        prog = Program(body=[
+            VarDecl("f", "file", CallExpr(Identifier("open"), [StringLiteral("t.txt"), StringLiteral("w")])),
+            ExprStmt(CallExpr(AttributeExpr(Identifier("f"), "write"), [StringLiteral("hi")])),
+            ExprStmt(CallExpr(AttributeExpr(Identifier("f"), "close"), []))
+        ])
+        TypeChecker().check(prog)


### PR DESCRIPTION
## Summary
- add `PbFile` struct and runtime helpers for file operations
- support `open()`, `file.read()`, `file.write()`, and `file.close()` in type checker and codegen
- map new `file` type to `PbFile` C struct
- test file handling in type checker and runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae3317a008321aac4e41724818d0d