### PR TITLE
Allow uninitialized fields in classes

### DIFF
--- a/src/lang_ast.py
+++ b/src/lang_ast.py
@@ -62,7 +62,7 @@ class GlobalStmt:
 class VarDecl:
     name: str
     declared_type: str
-    value: Expr
+    value: Optional[Expr] = None
     inferred_type: Optional[str] = None
 
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -629,17 +629,18 @@ class Parser:
         return ReturnStmt(value)
     
     def parse_var_decl(self) -> VarDecl:
-        """Parse a typed variable declaration with initializer
+        """Parse a typed variable declaration, optionally with an initializer
 
         Grammar fragment:
-        VarDecl ::= Identifier \":\" Type \"=\" Expr NEWLINE
+        VarDecl ::= Identifier ":" Type ["=" Expr] NEWLINE
         AST target: VarDecl(name, declared_type, value)
         """
         name = self.expect(TokenType.IDENTIFIER).value
         self.expect(TokenType.COLON)
         declared_type = self.parse_type()
-        self.expect(TokenType.ASSIGN)
-        value = self.parse_expr()
+        value: Optional[Expr] = None
+        if self.match(TokenType.ASSIGN):
+            value = self.parse_expr()
         self.expect(TokenType.NEWLINE)
         return VarDecl(name, declared_type, value)
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -765,6 +765,24 @@ class TestCodeGen(unittest.TestCase):
             "pb_print_int(Player_mp);"
         ])
 
+    def test_class_field_without_initializer(self):
+        program = Program(body=[
+            ClassDef(
+                name="Foo",
+                base=None,
+                fields=[VarDecl("attr1", "int", None)],
+                methods=[]
+            )
+        ])
+        output = codegen_output(program)
+
+        assert_contains_all(self, output, [
+            "typedef struct Foo {",
+            "int64_t attr1;",
+            "} Foo;",
+        ])
+        self.assertNotIn("Foo_attr1 =", output)
+
     def test_class_inheritance_with_fields(self):
         program = Program(body=[
             ClassDef(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -461,6 +461,15 @@ class TestParseStatements(ParserTestCase):
         self.assertIsInstance(stmt.value, Literal)
         self.assertEqual(stmt.value.raw, "42")
 
+    def test_parse_var_decl_without_initializer(self):
+        parser = self.parse_tokens("y: str\n")
+        stmt = parser.parse_var_decl()
+
+        self.assertIsInstance(stmt, VarDecl)
+        self.assertEqual(stmt.name, "y")
+        self.assertEqual(stmt.declared_type, "str")
+        self.assertIsNone(stmt.value)
+
     def test_parse_assign_stmt(self):
         parser = self.parse_tokens("x = y + 1\n")
         stmt = parser.parse_assign_stmt()
@@ -1107,8 +1116,10 @@ class TestParserEdgeCases(unittest.TestCase):
 
     # VarDecl missing initializer -------------------------------------
     def test_vardecl_without_initializer(self):
-        with self.assertRaises(ParserError):
-            self.parse_program("x: int\n")
+        prog = self.parse_program("x: int\n")
+        self.assertIsInstance(prog.body[0], VarDecl)
+        self.assertEqual(prog.body[0].name, "x")
+        self.assertIsNone(prog.body[0].value)
 
     # illegal break ----------------------------------------------------
     def test_break_outside_loop(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -411,6 +411,17 @@ class TestCodeGenFromSource(unittest.TestCase):
         # Optional: confirm static field initialization
         self.assertIn("int64_t Player_mp = 100;", c)
 
+    def test_class_field_without_initializer_pipeline(self):
+        code = (
+            "class Foo:\n"
+            "    a: int\n"
+        )
+
+        h, c = self.compile_pipeline(code)
+        self.assertIn("typedef struct Foo {", h)
+        self.assertIn("int64_t a;", h)
+        self.assertNotIn("Foo_a =", c)
+
     def test_codegen_class_inheritance_with_fields(self):
         code = (
             "class Player:\n"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -401,6 +401,22 @@ class TestPipelineRuntime(unittest.TestCase):
         self.assertEqual(lines[4], "200")
         self.assertEqual(lines[5], "150")
 
+    def test_class_field_without_initializer_runtime(self):
+        code = (
+            "class Foo:\n"
+            "    val: int\n"
+            "\n"
+            "    def __init__(self) -> None:\n"
+            "        self.val = 5\n"
+            "\n"
+            "def main() -> int:\n"
+            "    f: Foo = Foo()\n"
+            "    print(f.val)\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "5")
+
     def test_import_mathlib_add(self):
         modules = {
             "mathlib": (


### PR DESCRIPTION
## Summary
- support variable declarations without an initializer
- update parser and AST
- cover new behavior with parser/codegen/pipeline/runtime tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af2b9e3e88321818cd1e74f747957