### PR TITLE
Add comparison operators and chaining

### DIFF
--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -694,6 +694,38 @@ class TestCodeGen(unittest.TestCase):
             "return 0;"
         ])
 
+    def test_chained_comparison_codegen(self):
+        program = Program(body=[
+            FunctionDef(
+                name="main",
+                params=[],
+                return_type="int",
+                body=[
+                    VarDecl("x", "int", Literal("5")),
+                    IfStmt(branches=[
+                        IfBranch(
+                            BinOp(
+                                BinOp(Literal("1"), "<", Identifier("x")),
+                                "and",
+                                BinOp(Identifier("x"), "<", Literal("10"))
+                            ),
+                            [ExprStmt(CallExpr(Identifier("print"), [StringLiteral("ok")]))]
+                        )
+                    ]),
+                    ReturnStmt(Literal("0"))
+                ],
+                globals_declared=None
+            )
+        ])
+        output = codegen_output(program)
+        assert_contains_all(self, output, [
+            "int64_t x = 5;",
+            "if (((1 < x) && (x < 10))) {",
+            'pb_print_str("ok");',
+            "}",
+            "return 0;",
+        ])
+
     def test_class_attrs_and_dynamic_instance_attr(self):
         program = Program(body=[
             ClassDef(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -322,6 +322,50 @@ class TestParseExpressions(ParserTestCase):
         self.assertIsInstance(expr.right, Literal)
         self.assertEqual(expr.right.raw, "42")
 
+    def test_parse_comparison_lt(self):
+        parser = self.parse_tokens("x < 5")
+        expr = parser.parse_comparison()
+
+        self.assertIsInstance(expr, BinOp)
+        self.assertEqual(expr.op, "<")
+        self.assertIsInstance(expr.left, Identifier)
+        self.assertEqual(expr.left.name, "x")
+        self.assertIsInstance(expr.right, Literal)
+        self.assertEqual(expr.right.raw, "5")
+
+    def test_parse_comparison_lte(self):
+        parser = self.parse_tokens("x <= 5")
+        expr = parser.parse_comparison()
+
+        self.assertIsInstance(expr, BinOp)
+        self.assertEqual(expr.op, "<=")
+        self.assertIsInstance(expr.left, Identifier)
+        self.assertEqual(expr.left.name, "x")
+        self.assertIsInstance(expr.right, Literal)
+        self.assertEqual(expr.right.raw, "5")
+
+    def test_parse_comparison_gt(self):
+        parser = self.parse_tokens("x > 5")
+        expr = parser.parse_comparison()
+
+        self.assertIsInstance(expr, BinOp)
+        self.assertEqual(expr.op, ">")
+        self.assertIsInstance(expr.left, Identifier)
+        self.assertEqual(expr.left.name, "x")
+        self.assertIsInstance(expr.right, Literal)
+        self.assertEqual(expr.right.raw, "5")
+
+    def test_parse_comparison_gte(self):
+        parser = self.parse_tokens("x >= 5")
+        expr = parser.parse_comparison()
+
+        self.assertIsInstance(expr, BinOp)
+        self.assertEqual(expr.op, ">=")
+        self.assertIsInstance(expr.left, Identifier)
+        self.assertEqual(expr.left.name, "x")
+        self.assertIsInstance(expr.right, Literal)
+        self.assertEqual(expr.right.raw, "5")
+
     def test_parse_not_expr(self):
         parser = self.parse_tokens("not x == y")
         expr = parser.parse_not_expr()
@@ -1096,14 +1140,23 @@ class TestParserEdgeCases(unittest.TestCase):
         self.assertEqual(expr.op, "*")
         self.assertIsInstance(expr.left, UnaryOp)
 
-    def test_chained_comparison_illegal(self):
-        """
-        We expect a ParserError only when the whole line is parsed
-        as a statement (because the trailing '< c' is left over).
-        """
-        with self.assertRaises(ParserError):
-            # parse **program**, not just expression
-            self.parse_program("a < b < c\n")
+    def test_chained_comparison(self):
+        expr = self.parse_expr("a < b < c\n")
+
+        self.assertIsInstance(expr, BinOp)
+        self.assertEqual(expr.op, "and")
+        self.assertIsInstance(expr.left, BinOp)
+        self.assertEqual(expr.left.op, "<")
+        self.assertIsInstance(expr.left.left, Identifier)
+        self.assertEqual(expr.left.left.name, "a")
+        self.assertIsInstance(expr.left.right, Identifier)
+        self.assertEqual(expr.left.right.name, "b")
+        self.assertIsInstance(expr.right, BinOp)
+        self.assertEqual(expr.right.op, "<")
+        self.assertIsInstance(expr.right.left, Identifier)
+        self.assertEqual(expr.right.left.name, "b")
+        self.assertIsInstance(expr.right.right, Identifier)
+        self.assertEqual(expr.right.right.name, "c")
 
     # `is` and `is not` -----------------------------------------------
     def test_parse_is_operator(self):
@@ -1211,9 +1264,17 @@ class TestParserEdgeCases(unittest.TestCase):
         with self.assertRaises(ParserError):
             self.parse_program(bad)
 
-    def test_chained_comparison_error(self):
-        with self.assertRaises(ParserError):
-            self.parse_program("a < b < c\n")
+    def test_chained_comparison_in_if(self):
+        code = (
+            "def f() -> None:\n"
+            "    if a < b < c:\n"
+            "        pass\n"
+        )
+        func = Parser(self.lex(code)).parse_function_def()
+        cond = func.body[0].branches[0].condition
+
+        self.assertIsInstance(cond, BinOp)
+        self.assertEqual(cond.op, "and")
 
     def test_function_call_not_allowed_in_global_scope(self):
         self.assertRaisesRegex(ParserError, "Function call", self.parse_program, "print(5)\n")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -369,6 +369,18 @@ class TestCodeGenFromSource(unittest.TestCase):
         h, c = self.compile_pipeline(code)
         self.assertIn("if ((x && !(y))) {", c)
 
+    def test_chained_comparison_from_source(self):
+        code = (
+            "def main() -> int:\n"
+            "    x: int = 5\n"
+            "    if 1 < x < 10:\n"
+            "        print(\"ok\")\n"
+            "    return 0\n"
+        )
+        h, c = self.compile_pipeline(code)
+        self.assertIn("if (((1 < x) && (x < 10))) {", c)
+        self.assertIn('pb_print_str("ok");', c)
+
     # class ------------------------------------------------------
 
     def test_class_instantiation_and_method_call(self):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -163,6 +163,17 @@ class TestPipelineRuntime(unittest.TestCase):
         self.assertEqual(lines[0], "1.5")
         self.assertEqual(lines[1], "3.5")
 
+    def test_chained_comparison_runtime(self):
+        code = (
+            "def main() -> int:\n"
+            "    x: int = 5\n"
+            "    if 1 < x < 10:\n"
+            "        print(\"ok\")\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "ok")
+
     def test_list_indexing_and_printing(self):
         code = (
             "def main() -> int:\n"

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -127,6 +127,22 @@ class TestTypeCheckerInternals(unittest.TestCase):
         expr = BinOp(Literal("1"), "<", Literal("2"))
         self.assertEqual(self.tc.check_expr(expr), "bool")
 
+    def test_binop_lte(self):
+        expr = BinOp(Literal("1"), "<=", Literal("2"))
+        self.assertEqual(self.tc.check_expr(expr), "bool")
+
+    def test_binop_gt(self):
+        expr = BinOp(Literal("2"), ">", Literal("1"))
+        self.assertEqual(self.tc.check_expr(expr), "bool")
+
+    def test_binop_gte(self):
+        expr = BinOp(Literal("2"), ">=", Literal("1"))
+        self.assertEqual(self.tc.check_expr(expr), "bool")
+
+    def test_chained_comparison_type(self):
+        expr = BinOp(BinOp(Literal("1"), "<", Literal("2")), "and", BinOp(Literal("2"), "<", Literal("3")))
+        self.assertEqual(self.tc.check_expr(expr), "bool")
+
     def test_binop_is(self):
         expr = BinOp(Literal("None"), "is", Literal("None"))
         self.assertEqual(self.tc.check_expr(expr), "bool")


### PR DESCRIPTION
## Summary
- update parser to allow chained comparisons
- update docs in parse_comparison
- add tests for comparison ops in type checker
- add codegen, pipeline, and runtime tests for chained comparisons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0daec4288321978862525b68bea2