### PR TITLE
Improve imports and FString typing

### DIFF
--- a/src/codegen.py
+++ b/src/codegen.py
@@ -198,19 +198,36 @@ class CodeGen:
 
     def _emit_headers_and_runtime(self, include_self: bool = False, include_runtime: bool = True) -> None:
         """Emit required #include directives for runtime and imports."""
+        seen_includes: set[str] = set()
+        seen_aliases: set[str] = set()
+
+        def emit_include(path: str) -> None:
+            if path not in seen_includes:
+                self._emit(f'#include "{path}"')
+                seen_includes.add(path)
+
         if include_runtime:
-            self._emit('#include "pb_runtime.h"')
+            emit_include("pb_runtime.h")
         if include_self:
-            self._emit(f'#include "{self._get_module_name()}.h"')
+            emit_include(f"{self._get_module_name()}.h")
 
         for stmt in self._program.body:
             if isinstance(stmt, ImportStmt):
                 mod_name = ".".join(stmt.module)
                 alias = stmt.alias if stmt.alias else mod_name
                 self._modules.add(alias)
-                self._emit(f'#include "{mod_name}.h"')
+
+                emit_include(f"{mod_name}.h")
+
+                if not stmt.names and stmt.alias and stmt.alias != mod_name:
+                    if stmt.alias not in seen_aliases:
+                        self._emit(f"#define {stmt.alias} {mod_name}")
+                        seen_aliases.add(stmt.alias)
+
                 if stmt.names and stmt.alias and stmt.alias != stmt.names[0]:
-                    self._emit(f'#define {stmt.alias} {stmt.names[0]}')
+                    if stmt.alias not in seen_aliases:
+                        self._emit(f"#define {stmt.alias} {stmt.names[0]}")
+                        seen_aliases.add(stmt.alias)
 
         self._emit()
 

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -434,6 +434,7 @@ class TypeChecker:
             for part in expr.parts:
                 if isinstance(part, FStringExpr):
                     self.check_expr(part.expr)
+                    part.inferred_type = getattr(part.expr, "inferred_type", None)
             expr.inferred_type = "str"
             return "str"
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -865,8 +865,15 @@ class TestCodeGenFromSource(unittest.TestCase):
 
             h, c, *_ = compile_code_to_c_and_h(code, module_name="imports_extended", pb_path=imports_path)
 
-            self.assertIn('#include "mathlib.h"', c)
-            self.assertIn('#include "test_import.mathlib2.h"', c)
+            # Includes should only appear once despite multiple import forms
+            self.assertEqual(c.count('#include "mathlib.h"'), 1)
+            self.assertEqual(c.count('#include "test_import.mathlib2.h"'), 1)
+
+            # Alias macros should be generated for imported modules/symbols
+            self.assertIn('#define m1 mathlib', c)
+            self.assertIn('#define mathlib2 test_import.mathlib2', c)
+            self.assertIn('#define m2 test_import.mathlib2', c)
+            self.assertIn('#define pi2 PI', c)
 
 
 if __name__ == "__main__":

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -781,6 +781,8 @@ class TestTypeCheckerInternals(unittest.TestCase):
 
         # Additionally: ensure sub-expression is type-checked
         self.assertEqual(lit.parts[1].expr.inferred_type, "int")
+        # And the FStringExpr itself gets the propagated type
+        self.assertEqual(lit.parts[1].inferred_type, "int")
 
     def test_print_int(self):
         call = CallExpr(func=Identifier("print"), args=[Literal("42")])


### PR DESCRIPTION
## Summary
- deduplicate generated `#include` directives
- support module alias macros
- propagate inferred types for f-string expressions
- add tests for alias macros and f-string inferred types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bacd4c524832189b67c1e00f3f0a5