### PR TITLE
Implement str() conversion and list conversion tests

### DIFF
--- a/src/codegen.py
+++ b/src/codegen.py
@@ -1111,6 +1111,15 @@ class CodeGen:
                     return f"({self._expr(e.args[0])} != 0.0)"
                 else:
                     raise RuntimeError(f"`{fn_name}` conversion to `{e.args[0].inferred_type}` not supported yet!")
+            if fn_name == "str":
+                if e.args[0].inferred_type == "int":
+                    return f"pb_format_int({self._expr(e.args[0])})"
+                elif e.args[0].inferred_type == "float":
+                    return f"pb_format_double({self._expr(e.args[0])})"
+                elif e.args[0].inferred_type == "str":
+                    return f"{self._expr(e.args[0])}"
+                else:
+                    raise RuntimeError(f"`{fn_name}` conversion to `{e.args[0].inferred_type}` not supported yet!")
 
         # Method call: player.get_name() → Player__get_name(player)
         if isinstance(e.func, AttributeExpr):

--- a/src/pb_runtime.c
+++ b/src/pb_runtime.c
@@ -40,6 +40,15 @@ const char *pb_format_double(double x) {
     return bufs[i];
 }
 
+const char *pb_format_int(int64_t x) {
+    static char bufs[4][32];
+    static int i = 0;
+    i = (i + 1) % 4;
+
+    snprintf(bufs[i], sizeof(bufs[i]), "%" PRId64, x);
+    return bufs[i];
+}
+
 
 /* ------------ ERROR HANDLING ------------- */
 

--- a/src/pb_runtime.h
+++ b/src/pb_runtime.h
@@ -18,6 +18,7 @@ void pb_print_str(const char *s);
 void pb_print_bool(bool b);      
 
 const char *pb_format_double(double x);
+const char *pb_format_int(int64_t x);
 
 /* ------------ ERROR HANDLING ------------- */
 

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -1079,9 +1079,13 @@ class TypeChecker:
 
         # list indexing support
         elif isinstance(stmt.target, IndexExpr):
-            if getattr(stmt.target.base, "name") in self.env:
-                stmt.inferred_type = self.env[stmt.target.base.name]
-                stmt.target.base.inferred_type = self.env[stmt.target.base.name]
+            elem_type = self.check_expr(stmt.target)
+            value_type = self.check_expr(stmt.value)
+            if not types_match(value_type, elem_type):
+                raise TypeError(
+                    f"Type mismatch for indexed assignment: expected {elem_type}, got {value_type}"
+                )
+            stmt.inferred_type = stmt.target.inferred_type
             return
 
         else:

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1559,7 +1559,6 @@ class TestCodeGen(unittest.TestCase):
         macros = cg.generate_types_header()
         self.assertIn("PB_DECLARE_DICT(Item, struct Item *)", macros)
 
-<<<<<<< codex/fix-and-add-tests-for-list-conversions
     def test_list_conversion_functions(self):
         prog = Program(body=[
             FunctionDef(
@@ -1625,7 +1624,7 @@ class TestCodeGen(unittest.TestCase):
             "list_float_set(&arr3, 0, (double)(4));",
             "list_bool_set(&arr4, 0, (1 != 0));",
         ])
-=======
+
     def test_if_name_main_guard_codegen(self):
         prog = Program(body=[
             VarDecl("x", "int", Literal("1")),
@@ -1662,7 +1661,6 @@ class TestCodeGen(unittest.TestCase):
         self.assertIn('int64_t x = 1;', output)
         self.assertIn('pb_print_str((snprintf(__fbuf, 256, "%s", pb_format_double((x * 2.0))), __fbuf));', output)
         self.assertIn('pb_print_str((snprintf(__fbuf, 256, "%lld", (x * false)), __fbuf));', output)
->>>>>>> master
 
     def test_global_class_instances_codegen(self):
         prog = Program(body=[

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -759,6 +759,28 @@ class TestCodeGenFromSource(unittest.TestCase):
         self.assertIn("bool y_bool = (y != 0.0);", c)      # y to bool conversion
         self.assertIn("bool z_bool = (z != 0.0);", c)      # z to bool conversion
 
+    def test_list_conversion_functions(self):
+        code = (
+            "def main():\n"
+            "    arr: list[int] = [1, 2, 3]\n"
+            "    arr[0] = int(4.5)\n"
+            "    print(arr)\n"
+            "    arr2: list[str] = ['1', '2', '3']\n"
+            "    arr2[0] = str(4)\n"
+            "    print(arr2)\n"
+            "    arr3: list[float] = [1.1, 2.2, 3.3]\n"
+            "    arr3[0] = float(4)\n"
+            "    print(arr3)\n"
+            "    arr4: list[bool] = [True, False]\n"
+            "    arr4[0] = bool(1)\n"
+            "    print(arr4)\n"
+        )
+        h, c = self.compile_pipeline(code)
+
+        self.assertIn('list_int_set(&arr, 0, (int64_t)(4.5));', c)
+        self.assertIn('list_str_set(&arr2, 0, pb_format_int(4));', c)
+        self.assertIn('list_float_set(&arr3, 0, (double)(4));', c)
+        self.assertIn('list_bool_set(&arr4, 0, (1 != 0));', c)
     def test_fstring_expression_codegen(self):
         code = (
             "class Player:\n"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -313,6 +313,28 @@ class TestPipelineRuntime(unittest.TestCase):
         self.assertEqual(lines[5], "y: 1.0, y_bool: True")    # y to bool
         self.assertEqual(lines[6], "z: 0.0, z_bool: False")    # z to bool
 
+    def test_list_conversion_functions_runtime(self):
+        code = (
+            "def main():\n"
+            "    arr: list[int] = [1, 2, 3]\n"
+            "    arr[0] = int(4.5)\n"
+            "    print(arr)\n"
+            "    arr2: list[str] = ['1', '2', '3']\n"
+            "    arr2[0] = str(4)\n"
+            "    print(arr2)\n"
+            "    arr3: list[float] = [1.1, 2.2, 3.3]\n"
+            "    arr3[0] = float(4)\n"
+            "    print(arr3)\n"
+            "    arr4: list[bool] = [True, False]\n"
+            "    arr4[0] = bool(1)\n"
+            "    print(arr4)\n"
+        )
+        output = compile_and_run(code)
+        lines = output.strip().splitlines()
+        self.assertEqual(lines[0], "[4, 2, 3]")
+        self.assertEqual(lines[1], "['4', '2', '3']")
+        self.assertEqual(lines[2], "[4, 2.2, 3.3]")
+        self.assertEqual(lines[3], "[True, False]")
     def test_fstring_expression_variants(self):
         code = (
             "class Player:\n"


### PR DESCRIPTION
## Summary
- implement `pb_format_int` helper in runtime
- support `str()` built‑in conversion in codegen
- validate indexed assignment types in type checker
- add unit tests for list conversion functions in pipeline, runtime, and codegen
- adjust existing `test_list_str_operations` to expect quoted constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c41a7fa848321b683d3b96ffc10f2