### PR TITLE
Fix list assignment index bounds

### DIFF
--- a/src/pb_runtime.c
+++ b/src/pb_runtime.c
@@ -267,10 +267,8 @@ void list_int_init(List_int *lst) {
 }
 
 void list_int_set(List_int *lst, int64_t index, int64_t value) {
-    if (index < 0 || index > lst->len) {
+    if (index < 0 || index >= lst->len) {
         pb_index_error("int", "set", index, lst->len, lst);
-    } else if (index == lst->len) {
-        list_int_append(lst, value);
     } else {
         lst->data[index] = value;
     }
@@ -353,10 +351,8 @@ void list_float_init(List_float *lst) {
 }
 
 void list_float_set(List_float *lst, int64_t index, double value) {
-    if (index < 0 || index > lst->len) {
+    if (index < 0 || index >= lst->len) {
         pb_index_error("float", "set", index, lst->len, lst);
-    } else if (index == lst->len) {
-        list_float_append(lst, value);
     } else {
         lst->data[index] = value;
     }
@@ -438,10 +434,8 @@ void list_bool_init(List_bool *lst) {
 }
 
 void list_bool_set(List_bool *lst, int64_t index, bool value) {
-    if (index < 0 || index > lst->len) {
+    if (index < 0 || index >= lst->len) {
         pb_index_error("bool", "set", index, lst->len, lst);
-    } else if (index == lst->len) {
-        list_bool_append(lst, value);
     } else {
         lst->data[index] = value;
     }
@@ -523,10 +517,8 @@ void list_str_init(List_str *lst) {
 }
 
 void list_str_set(List_str *lst, int64_t index, const char *value) {
-    if (index < 0 || index > lst->len) {
+    if (index < 0 || index >= lst->len) {
         pb_index_error("str", "set", index, lst->len, lst);
-    } else if (index == lst->len) {
-        list_str_append(lst, value);
     } else {
         lst->data[index] = value;  // assumes value is valid for the lifetime of lst
     }

--- a/tests/test_pb_match_python.py
+++ b/tests/test_pb_match_python.py
@@ -35,5 +35,30 @@ class TestRefLangOutputMatch(unittest.TestCase):
 
         self.assertEqual(output_python, output_pb, "PB and Python outputs differ")
 
+    def test_list_indexing_python_vs_pb_output(self):
+        pb_path = os.path.join(root_dir, "examples", "list_indexing.pb")
+        run_pb_script = os.path.join(root_dir, "run_pb_as_python.py")
+        pb_main = os.path.join(root_dir, "src", "main.py")
+
+        py_result = subprocess.run(
+            [sys.executable, run_pb_script, pb_path],
+            capture_output=True,
+            text=True,
+            cwd=root_dir,
+        )
+        self.assertEqual(py_result.returncode, 0, f"Python run failed:\n{py_result.stderr}")
+        output_python = py_result.stdout.strip().splitlines()
+
+        pb_result = subprocess.run(
+            [sys.executable, pb_main, "run", pb_path],
+            capture_output=True,
+            text=True,
+            cwd=os.path.join(root_dir, "src"),
+        )
+        self.assertEqual(pb_result.returncode, 0, f"PB run failed:\n{pb_result.stderr}")
+        output_pb = pb_result.stdout.strip().splitlines()
+
+        self.assertEqual(output_python, output_pb, "PB and Python outputs differ")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -223,18 +223,37 @@ class TestPipelineRuntime(unittest.TestCase):
             "    print(a)\n"
             "    print(x)\n"
             "    b: list[int] = []\n"
-            "    b[0] = 1\n"
-            "    y: int = b[0]\n"
-            "    print(b)\n"
-            "    print(y)\n"
+            "    try:\n"
+            "        b[0] = 1\n"
+            "    except IndexError:\n"
+            "        print('caught')\n"
             "    return 0\n"
         )
         output = compile_and_run(code)
         lines = output.strip().splitlines()
         self.assertEqual(lines[0], "[10]")
         self.assertEqual(lines[1], "10")
-        self.assertEqual(lines[2], "[1]")
-        self.assertEqual(lines[3], "1")
+        self.assertEqual(lines[2], "caught")
+
+    def test_list_assignment_out_of_bounds_runtime(self):
+        code = (
+            "def main() -> int:\n"
+            "    arr: list[str] = ['a', 'b']\n"
+            "    print(arr[0])\n"
+            "    try:\n"
+            "        arr[2] = 'c'\n"
+            "    except IndexError:\n"
+            "        print('caught')\n"
+            "    print(arr[0])\n"
+            "    print(arr)\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        lines = output.strip().splitlines()
+        self.assertEqual(lines[0], 'a')
+        self.assertEqual(lines[1], 'caught')
+        self.assertEqual(lines[2], 'a')
+        self.assertEqual(lines[3], "['a', 'b']")
 
     def test_set_literal_runtime(self):
         code = (


### PR DESCRIPTION
## Summary
- raise `IndexError` when assigning at or beyond list length
- ensure PB runtime matches Python for list assignment errors
- update tests for runtime and add regression test comparing PB to Python output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5e93bb9c83219d405093e3263bcf