### PR TITLE
Add list methods append/pop/remove

### DIFF
--- a/examples/arr_rw.pb
+++ b/examples/arr_rw.pb
@@ -10,7 +10,7 @@ def main():
         b[0] = 1
     except IndexError:
          print("IndexError")
-         b = [1]
+         b.append(1)
     y: int = b[0] 
     print(b)
     print(y)

--- a/examples/list_methods.pb
+++ b/examples/list_methods.pb
@@ -1,0 +1,20 @@
+def main():
+    nums: list[int] = [1, 2]
+    nums.append(3)
+    print(nums)
+    last: int = nums.pop()
+    print(last)
+    print(nums)
+    nums.append(4)
+    nums.remove(1)
+    print(nums)
+
+    words: list[str] = []
+    words.append("a")
+    print(words.pop())
+    words.append("b")
+    words.remove("b")
+    print(words)
+
+if __name__ == "__main__":
+    main()

--- a/src/pb_runtime.c
+++ b/src/pb_runtime.c
@@ -247,13 +247,26 @@ void pb_index_error(const char *type, const char *op, int64_t index, int64_t len
 void list_int_grow_if_needed(List_int *lst) {
     if (lst->len >= lst->capacity) {
         int64_t new_capacity = (lst->capacity == 0) ? INITIAL_LIST_CAPACITY : (lst->capacity * 2);
-        int64_t *new_data = (int64_t *)realloc(lst->data, new_capacity * sizeof(int64_t));
-        if (!new_data) {
-            char buf[128];
-            snprintf(buf, sizeof(buf),
-                "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64,
-                "int", lst->capacity);
-            pb_fail(buf);
+        int64_t *new_data;
+        if (lst->capacity == 0 && lst->data != NULL) {
+            new_data = (int64_t *)malloc(new_capacity * sizeof(int64_t));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64,
+                    "int", lst->capacity);
+                pb_fail(buf);
+            }
+            memcpy(new_data, lst->data, lst->len * sizeof(int64_t));
+        } else {
+            new_data = (int64_t *)realloc(lst->data, new_capacity * sizeof(int64_t));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64,
+                    "int", lst->capacity);
+                pb_fail(buf);
+            }
         }
         lst->data = new_data;
         lst->capacity = new_capacity;
@@ -332,12 +345,24 @@ void list_int_print(const List_int *lst) {
 void list_float_grow_if_needed(List_float *lst) {
     if (lst->len >= lst->capacity) {
         int64_t new_capacity = (lst->capacity == 0) ? INITIAL_LIST_CAPACITY : (lst->capacity * 2);
-        double *new_data = (double *)realloc(lst->data, new_capacity * sizeof(double));
-        if (!new_data) {
-            char buf[128];
-            snprintf(buf, sizeof(buf),
-                "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
-            pb_fail(buf);
+        double *new_data;
+        if (lst->capacity == 0 && lst->data != NULL) {
+            new_data = (double *)malloc(new_capacity * sizeof(double));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
+                pb_fail(buf);
+            }
+            memcpy(new_data, lst->data, lst->len * sizeof(double));
+        } else {
+            new_data = (double *)realloc(lst->data, new_capacity * sizeof(double));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
+                pb_fail(buf);
+            }
         }
         lst->data = new_data;
         lst->capacity = new_capacity;
@@ -420,12 +445,24 @@ void list_float_print(const List_float *lst) {
 void list_bool_grow_if_needed(List_bool *lst) {
     if (lst->len >= lst->capacity) {
         int64_t new_capacity = (lst->capacity == 0) ? INITIAL_LIST_CAPACITY : (lst->capacity * 2);
-        bool *new_data = (bool *)realloc(lst->data, new_capacity * sizeof(bool));
-        if (!new_data) {
-            char buf[128];
-            snprintf(buf, sizeof(buf),
-                "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
-            pb_fail(buf);
+        bool *new_data;
+        if (lst->capacity == 0 && lst->data != NULL) {
+            new_data = (bool *)malloc(new_capacity * sizeof(bool));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
+                pb_fail(buf);
+            }
+            memcpy(new_data, lst->data, lst->len * sizeof(bool));
+        } else {
+            new_data = (bool *)realloc(lst->data, new_capacity * sizeof(bool));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
+                pb_fail(buf);
+            }
         }
         lst->data = new_data;
         lst->capacity = new_capacity;
@@ -503,12 +540,24 @@ void list_bool_print(const List_bool *lst) {
 void list_str_grow_if_needed(List_str *lst) {
     if (lst->len >= lst->capacity) {
         int64_t new_capacity = (lst->capacity == 0) ? INITIAL_LIST_CAPACITY : (lst->capacity * 2);
-        const char **new_data = (const char **)realloc(lst->data, new_capacity * sizeof(const char *));
-        if (!new_data) {
-            char buf[128];
-            snprintf(buf, sizeof(buf),
-                "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
-            pb_fail(buf);
+        const char **new_data;
+        if (lst->capacity == 0 && lst->data != NULL) {
+            new_data = (const char **)malloc(new_capacity * sizeof(const char *));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
+                pb_fail(buf);
+            }
+            memcpy(new_data, lst->data, lst->len * sizeof(const char *));
+        } else {
+            new_data = (const char **)realloc(lst->data, new_capacity * sizeof(const char *));
+            if (!new_data) {
+                char buf[128];
+                snprintf(buf, sizeof(buf),
+                    "Failed to allocate memory while growing list[%s]: old capacity = %" PRId64, "int", lst->capacity);
+                pb_fail(buf);
+            }
         }
         lst->data = new_data;
         lst->capacity = new_capacity;

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1833,6 +1833,32 @@ class TestCodeGen(unittest.TestCase):
             "pb_print_int(l);",
         ])
 
+    def test_list_methods_codegen(self):
+        prog = Program(body=[
+            FunctionDef(
+                name="main",
+                params=[],
+                return_type="int",
+                body=[
+                    VarDecl("arr", "list[int]", ListExpr(elements=[Literal("1"), Literal("2")], elem_type="int", inferred_type="list[int]")),
+                    ExprStmt(CallExpr(AttributeExpr(Identifier("arr"), "append"), [Literal("3")])),
+                    VarDecl("x", "int", CallExpr(AttributeExpr(Identifier("arr"), "pop"), [])),
+                    VarDecl("r", "bool", CallExpr(AttributeExpr(Identifier("arr"), "remove"), [Literal("1")])),
+                    ReturnStmt(Literal("0"))
+                ],
+                globals_declared=None
+            )
+        ])
+        output = codegen_output(prog)
+        assert_contains_all(self, output, [
+            "int64_t __tmp_list_1[] = {1, 2};",
+            "List_int arr = (List_int){ .len=2, .data=__tmp_list_1 };",
+            "list_int_append(&arr, 3);",
+            "int64_t x = list_int_pop(&arr);",
+            "bool r = list_int_remove(&arr, 1);",
+            "return 0;",
+        ])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pb_match_python.py
+++ b/tests/test_pb_match_python.py
@@ -105,6 +105,12 @@ class TestExamplesPythonVsPb(RuntimeHelper):
         out_pb = self._run_pb(path)
         self.assertEqual(out_py, out_pb)
 
+    def test_list_methods(self):
+        path = os.path.join(examples_dir, "list_methods.pb")
+        out_py = self._run_python(path)
+        out_pb = self._run_pb(path)
+        self.assertEqual(out_py, out_pb)
+
     def test_test(self):
         path = os.path.join(examples_dir, "test.pb")
         out_py = self._run_python(path)

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -2629,3 +2629,15 @@ class TestTypeCheckerProgramLevel(unittest.TestCase):
         ])
         checker = TypeChecker().check(prog)
         self.assertEqual(checker.body[1].inferred_type, "int")
+
+    def test_list_methods(self):
+        prog = Program(body=[
+            VarDecl("arr", "list[int]", ListExpr(elements=[Literal("1"), Literal("2")])),
+            ExprStmt(CallExpr(AttributeExpr(Identifier("arr"), "append"), [Literal("3")])),
+            VarDecl("x", "int", CallExpr(AttributeExpr(Identifier("arr"), "pop"), [])),
+            VarDecl("r", "bool", CallExpr(AttributeExpr(Identifier("arr"), "remove"), [Literal("1")])),
+        ])
+        checker = TypeChecker().check(prog)
+        self.assertEqual(checker.body[1].expr.inferred_type, "None")
+        self.assertEqual(checker.body[2].inferred_type, "int")
+        self.assertEqual(checker.body[3].inferred_type, "bool")


### PR DESCRIPTION
## Summary
- implement list `append`, `pop`, and `remove` methods
- handle lists created from literals when grown
- update arr_rw example to use `b.append(1)`
- add comprehensive list methods example
- extend type checker and code generator to support the new methods
- add unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d112e49508321b11543b6d120f1a1