### PR TITLE
Fix set literal uniqueness

### DIFF
--- a/src/codegen.py
+++ b/src/codegen.py
@@ -1310,9 +1310,17 @@ class CodeGen:
             self._emit(f"{elem_c_type} {buf_name}[1] = {{0}};")
             return f"({set_c_type}){{ .len=0, .data={buf_name} }}"
         else:
-            elems = ", ".join(self._expr(x) for x in e.elements)
+            unique_codes = []
+            seen = set()
+            for el in e.elements:
+                code = self._expr(el)
+                if code not in seen:
+                    seen.add(code)
+                    unique_codes.append(code)
+
+            elems = ", ".join(unique_codes)
             self._emit(f"{elem_c_type} {buf_name}[] = {{{elems}}};")
-            return f"({set_c_type}){{ .len={len(e.elements)}, .data={buf_name} }}"
+            return f"({set_c_type}){{ .len={len(unique_codes)}, .data={buf_name} }}"
 
     def _generate_DictExpr(self, e: DictExpr) -> str:
         self._tmp_dict_counter += 1

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -360,7 +360,7 @@ class TestPipelineRuntime(unittest.TestCase):
         )
         output = compile_and_run(code)
         lines = output.strip().splitlines()
-        self.assertEqual(lines[0], "{True, False, True}")
+        self.assertEqual(lines[0], "{True, False}")
 
     def test_type_conversions_and_printing(self):
         code = (


### PR DESCRIPTION
## Summary
- deduplicate elements when generating set literals
- adjust runtime test to expect unique boolean set printing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a0d76fb8832181c4a03cd0a4cda4