### PR TITLE
Add negative hex formatting

### DIFF
--- a/ref/spec.md
+++ b/ref/spec.md
@@ -34,10 +34,11 @@ raise, return, True, try, while
 
 ### Literals
 
-* Integer literals: `42`, `1_000`
+* Integer literals: `42`, `1_000`, `0x00000008`
 * Float literals: `3.14`, `1_000.0`, `6.022_140e23`
     - Underscores may separate digits anywhere; they are stripped at lexing.
     - At least one digit before and after the dot; no leading-dot (`.5`) or trailing-dot (`5.`) forms are allowed.
+    - Hexadecimal integers start with `0x` or `0X` and may contain underscores.
 * String literals: single- or double-quoted, single-line only (e.g., `"Hello"`, `'world'`). Escape sequences (`\n`, `\\`, etc.) are decoded; invalid escapes raise a `LexerError` with the raw lexeme.
 * F-string literals: `f"..."` or `f'...'`, single-line only.
     - Placeholders use `{expr}` syntax where `expr` is a full expression (e.g., `x`, `a + b`, `obj.attr`, `call()`).
@@ -97,7 +98,7 @@ settings: dict[str, int] = {"volume": 10}
 
 * **No implicit coercion** is performed between unrelated types (e.g., `str → int`, or unrelated classes).
 
-* **Explicit conversion** is still available using built-in constructors: `int(x)`, `float(x)`, `str(x)`, `bool(x)`.
+* **Explicit conversion** is still available using built-in constructors: `int(x)`, `float(x)`, `str(x)`, `bool(x)`, `hex(x)`.
 
 ---
 
@@ -248,8 +249,10 @@ modules against these signatures.
 
 ## 8. Built-in Functions
 
-`print`, `range`.  
+`print`, `range`, `hex`.
 `print` chooses helper (`pb_print_int`, `pb_print_bool`, …) based on static type.
+`hex(x)` returns a zero-padded hexadecimal string. Negative values are prefixed
+with `-0x`.
 
 ---
 

--- a/src/codegen.py
+++ b/src/codegen.py
@@ -1194,6 +1194,11 @@ class CodeGen:
                     return f"{self._expr(e.args[0])}"
                 else:
                     raise RuntimeError(f"`{fn_name}` conversion to `{e.args[0].inferred_type}` not supported yet!")
+            if fn_name == "hex":
+                if e.args[0].inferred_type == "int":
+                    return f"pb_format_hex({self._expr(e.args[0])})"
+                else:
+                    raise RuntimeError(f"`{fn_name}` conversion to `{e.args[0].inferred_type}` not supported yet!")
 
         # Method call: player.get_name() → Player__get_name(player)
         if isinstance(e.func, AttributeExpr):

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -145,6 +145,7 @@ TOKEN_REGEX = [
     (re.compile(r'\|'), TokenType.PIPE),
     
     # numeric literals (underscore allowed)
+    (re.compile(r"0[xX][0-9a-fA-F][0-9a-fA-F_]*"), TokenType.INT_LIT),
     (re.compile(r'\d[\d_]*\.\d[\d_]*[eE][+-]?\d[\d_]*'), TokenType.FLOAT_LIT),  # Fraction + Exponent; 12.34e5, 6.02_2e+23
     (re.compile(r'\d[\d_]*[eE][+-]?\d[\d_]*'), TokenType.FLOAT_LIT),            # Integer + Exponent; 10e-3, 1_6e2
     (re.compile(r'\d[\d_]*\.\d[\d_]*'), TokenType.FLOAT_LIT),                   # Simple Fraction (no exponent); 3.1415, 0.5, 2_5.0

--- a/src/pb_runtime.c
+++ b/src/pb_runtime.c
@@ -49,6 +49,21 @@ const char *pb_format_int(int64_t x) {
     return bufs[i];
 }
 
+const char *pb_format_hex(int64_t x) {
+    static char bufs[4][32];
+    static int i = 0;
+    i = (i + 1) % 4;
+
+    if (x < 0) {
+        uint32_t val = (uint32_t)(-x);
+        snprintf(bufs[i], sizeof(bufs[i]), "-0x%08" PRIx32, val);
+    } else {
+        uint32_t val = (uint32_t)x;
+        snprintf(bufs[i], sizeof(bufs[i]), "0x%08" PRIx32, val);
+    }
+    return bufs[i];
+}
+
 
 /* ------------ ERROR HANDLING ------------- */
 

--- a/src/pb_runtime.h
+++ b/src/pb_runtime.h
@@ -19,6 +19,7 @@ void pb_print_bool(bool b);
 
 const char *pb_format_double(double x);
 const char *pb_format_int(int64_t x);
+const char *pb_format_hex(int64_t x);
 
 /* ------------ ERROR HANDLING ------------- */
 

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -590,6 +590,14 @@ class TypeChecker:
                         raise TypeError(f"Function 'str' expects int, float, or str, got {arg_type}")
                     expr.inferred_type = "str"
                     return "str"
+                if fname == "hex":
+                    if len(expr.args) != 1:
+                        raise TypeError("Function 'hex' expects exactly one argument")
+                    arg_type = self.check_expr(expr.args[0])
+                    if arg_type != "int":
+                        raise TypeError(f"Function 'hex' expects int, got {arg_type}")
+                    expr.inferred_type = "str"
+                    return "str"
                 if fname == "open":
                     if len(expr.args) != 2:
                         raise TypeError("Function 'open' expects exactly two arguments")

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -547,5 +547,10 @@ class TestFStringLexing(unittest.TestCase):
         self.assertEqual(len(comments), 1)
         self.assertEqual(comments[0].value, "# important")
 
+    def test_hex_integer_literal(self):
+        tokens = Lexer('value = 0x00000008').tokenize()
+        values = [t.value for t in tokens if t.type == TokenType.INT_LIT]
+        self.assertIn('0x00000008', values)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -115,6 +115,12 @@ class TestParseExpressions(ParserTestCase):
         self.assertIsInstance(lit, Literal)
         self.assertEqual(lit.raw, "42")
 
+    def test_parse_literal_hex_int(self):
+        parser = self.parse_tokens("0x00000008")
+        lit = parser.parse_literal()
+        self.assertIsInstance(lit, Literal)
+        self.assertEqual(lit.raw, "0x00000008")
+
     def test_parse_literal_float(self):
         parser = self.parse_tokens("3.14")
         lit = parser.parse_literal()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1050,6 +1050,26 @@ class TestCodeGenFromSource(unittest.TestCase):
         self.assertIn('int64_t n = 10;', c)
         self.assertIn('for (int64_t i = 0; i < n; ++i)', c)
 
+    def test_hex_builtin_codegen(self):
+        code = (
+            "def main() -> int:\n"
+            "    x: int = 0x00000008\n"
+            "    print(hex(x))\n"
+            "    return 0\n"
+        )
+        h, c = self.compile_pipeline(code)
+        self.assertIn('pb_format_hex(x)', c)
+
+    def test_hex_negative_codegen(self):
+        code = (
+            "def main() -> int:\n"
+            "    x: int = -10\n"
+            "    print(hex(x))\n"
+            "    return 0\n"
+        )
+        h, c = self.compile_pipeline(code)
+        self.assertIn('pb_format_hex(x)', c)
+
     def test_len_builtin_pipeline(self):
         code = (
             "def main() -> int:\n"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -781,6 +781,26 @@ class TestPipelineRuntime(unittest.TestCase):
         output = compile_and_run(code)
         self.assertEqual(output.strip(), "45")
 
+    def test_hex_literal_and_format(self):
+        code = (
+            "def main() -> int:\n"
+            "    x: int = 0x00000008\n"
+            "    print(hex(x))\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "0x00000008")
+
+    def test_hex_negative_format(self):
+        code = (
+            "def main() -> int:\n"
+            "    x: int = -10\n"
+            "    print(hex(x))\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "-0x0000000a")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support negative integers in `pb_format_hex`
- document `hex` builtin behaviour
- test negative hex formatting at codegen and runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679293ab8083219cf21e8763169694