### PR TITLE
Implement native binding module support

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -77,7 +77,8 @@ def build(source_code: str, pb_path: str, output_file: str, verbose: bool = Fals
         if not hasattr(mod, "program"):
             continue  # Defensive: only process modules with AST
         c_file = write_module_code_files(mod, build_dir, verbose, debug)
-        module_c_files.append(c_file)
+        if c_file:
+            module_c_files.append(c_file)
 
     c_path = get_build_output_path(f"{output_file}.c")
     module_c_files.append(c_path)
@@ -142,6 +143,11 @@ def get_build_output_path(output_file: str) -> str:
 
 
 def write_module_code_files(mod_symbol, build_dir, verbose: bool = False, debug: bool = False):
+    if getattr(mod_symbol, "native_binding", False):
+        if verbose:
+            print(f"Skipping code generation for native binding module: {mod_symbol.name}")
+        return None
+
     # Derive path: e.g. "foo/bar" -> "build/foo/bar.h", "build/foo/bar.c"
     rel_path = mod_symbol.name.replace(".", os.sep)
     mod_dir = os.path.join(build_dir, os.path.dirname(rel_path))

--- a/src/pb_pipeline.py
+++ b/src/pb_pipeline.py
@@ -6,7 +6,7 @@ from type_checker import TypeChecker, TypeError
 from codegen import CodeGen
 from lang_ast import ImportStmt, ImportFromStmt, ImportAlias, Program, Stmt
 from module_loader import load_module, ModuleNotFoundError
-from module_loader import get_std_vendor_paths
+from module_loader import get_std_vendor_paths, is_native_binding
 
 
 def process_imports(ast: Program, pb_path: str, verbose: bool = False):
@@ -127,6 +127,9 @@ def compile_code_to_c_and_h(
     )
     if ast is None:
         return None, None, None, loaded_modules
+    if pb_path and is_native_binding(pb_path):
+        # Skip code generation for native bindings
+        return None, None, ast, loaded_modules
     codegen = CodeGen()
     h_code = codegen.generate_header(ast)
     c_code = codegen.generate(ast)

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -181,6 +181,7 @@ class ModuleSymbol:
         exports: dict | None = None,
         functions: dict | None = None,
         vendor_metadata=None,
+        native_binding: bool = False,
     ):
         self.name = name
         self.path = path  # Optional: absolute path to module file
@@ -188,6 +189,7 @@ class ModuleSymbol:
         self.functions = functions if functions is not None else {}
         self.program: Program | None = program
         self.vendor_metadata: dict | None = vendor_metadata
+        self.native_binding: bool = native_binding
 
 
 class TypeError(Exception):

--- a/tests/test_native_binding.py
+++ b/tests/test_native_binding.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+
+from pb_pipeline import compile_code_to_c_and_h
+from module_loader import load_module
+from main import collect_vendor_build_info, write_module_code_files
+
+
+def create_binding_module(tmpdir):
+    mod_dir = os.path.join(tmpdir, "vendor", "testlib")
+    os.makedirs(mod_dir, exist_ok=True)
+    pb_path = os.path.join(mod_dir, "testlib.pb")
+    with open(pb_path, "w") as f:
+        f.write("# PB_MODULE_KIND: NATIVE_BINDING\n")
+        f.write("def add(x: int, y: int) -> int:\n    return 0\n")
+    meta_path = os.path.join(mod_dir, "metadata.toml")
+    with open(meta_path, "w") as f:
+        f.write("link_flags = ['-ltest']\n")
+    return pb_path, mod_dir
+
+
+def test_compile_binding_skips_codegen():
+    with tempfile.TemporaryDirectory() as tmp:
+        pb_path, _ = create_binding_module(tmp)
+        with open(pb_path) as f:
+            source = f.read()
+        h, c, ast, mods = compile_code_to_c_and_h(source, module_name="testlib", pb_path=pb_path)
+        assert h is None and c is None
+        assert ast is not None
+        assert mods == {}
+
+
+def test_load_module_binding_metadata():
+    with tempfile.TemporaryDirectory() as tmp:
+        pb_path, mod_dir = create_binding_module(tmp)
+        loaded = {}
+        mod = load_module(["testlib"], [mod_dir], loaded)
+        assert mod.native_binding
+        assert mod.vendor_metadata == {"link_flags": ["-ltest"]}
+        inc, lib, flags = collect_vendor_build_info(loaded)
+        assert "-ltest" in flags
+        # write_module_code_files should return None
+        assert write_module_code_files(mod, mod_dir) is None
+

--- a/vendor/raylib/raylib.pb
+++ b/vendor/raylib/raylib.pb
@@ -1,3 +1,4 @@
+# PB_MODULE_KIND: NATIVE_BINDING
 # Auto-generated PB bindings for raylib
 
 RAYLIB_H: int = ...


### PR DESCRIPTION
## Summary
- mark raylib binding with PB_MODULE_KIND: NATIVE_BINDING
- detect native binding modules in module_loader
- skip code generation for bindings in pipeline and build helpers
- expose native_binding flag on ModuleSymbol
- add tests for native binding behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867fcfeb20c8321bb9deaedcd4bc867