### PR TITLE
Support native vendor modules via JSON metadata

### DIFF
--- a/src/pb_pipeline.py
+++ b/src/pb_pipeline.py
@@ -96,13 +96,13 @@ def compile_code_to_ast(
     if debug and pprint:
         print("PARSER AST:\n"); pprint(ast); print(f"{'-'*80}\n")
 
-    checker = TypeChecker()
+    checker = TypeChecker(native_module=is_native_binding(pb_path) if pb_path else False)
     loaded_modules = {}
 
     if import_support and pb_path is not None:
         checker, loaded_modules = process_imports(ast, pb_path, verbose=verbose)
     else:
-        checker = TypeChecker()
+        checker = TypeChecker(native_module=is_native_binding(pb_path) if pb_path else False)
         loaded_modules = {}
 
     checker.check(ast)

--- a/tests/test_native_binding.py
+++ b/tests/test_native_binding.py
@@ -11,11 +11,10 @@ def create_binding_module(tmpdir):
     os.makedirs(mod_dir, exist_ok=True)
     pb_path = os.path.join(mod_dir, "testlib.pb")
     with open(pb_path, "w") as f:
-        f.write("# PB_MODULE_KIND: NATIVE_BINDING\n")
         f.write("def add(x: int, y: int) -> int:\n    return 0\n")
-    meta_path = os.path.join(mod_dir, "metadata.toml")
+    meta_path = os.path.join(mod_dir, "metadata.json")
     with open(meta_path, "w") as f:
-        f.write("link_flags = ['-ltest']\n")
+        f.write('{"link_flags": ["-ltest"], "native": true}')
     return pb_path, mod_dir
 
 
@@ -36,7 +35,7 @@ def test_load_module_binding_metadata():
         loaded = {}
         mod = load_module(["testlib"], [mod_dir], loaded)
         assert mod.native_binding
-        assert mod.vendor_metadata == {"link_flags": ["-ltest"]}
+        assert mod.vendor_metadata == {"link_flags": ["-ltest"], "native": True}
         inc, lib, flags = collect_vendor_build_info(loaded)
         assert "-ltest" in flags
         # write_module_code_files should return None

--- a/vendor/raylib/metadata.json
+++ b/vendor/raylib/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "raylib",
+  "version": "5.5",
+  "include_dirs": ["include"],
+  "lib_dirs": ["lib/windows"],
+  "link_flags": ["-lraylib", "-lgdi32", "-lwinmm"],
+  "native": true
+}

--- a/vendor/raylib/metadata.toml
+++ b/vendor/raylib/metadata.toml
@@ -1,5 +1,0 @@
-name = "raylib"
-version = "5.5"
-include_dirs = ["include"]
-link_flags = ["-lraylib", "-lgdi32", "-lwinmm"]
-lib_dirs = ["lib/windows"]


### PR DESCRIPTION
## Summary
- detect vendor bindings using `metadata.json` instead of comments
- skip return checks when type-checking native modules
- track native imports for code generation
- avoid name mangling for native functions
- update raylib metadata and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683139e78483219b540ea1036d7424