### PR TITLE
Fix native module call prefix

### DIFF
--- a/src/codegen.py
+++ b/src/codegen.py
@@ -99,6 +99,9 @@ class CodeGen:
         # Names of all classes in the current program
         self._class_names: set[str] = set()
 
+        # Track which imported functions originate from native modules
+        self._native_functions: dict[str, bool] = {}
+
     def _attr_full_name(self, expr: Expr) -> str | None:
         if isinstance(expr, Identifier):
             return expr.name
@@ -124,6 +127,7 @@ class CodeGen:
         self._program = program
         self._modules = getattr(program, "import_aliases", {}).copy()
         self._native_modules = getattr(program, "native_modules", {})
+        self._native_functions = getattr(program, "native_functions", {})
         self._lines.clear()
         self._indent = 0
         self._runtime_emitted = False
@@ -170,6 +174,7 @@ class CodeGen:
         self._program = program
         self._modules = getattr(program, "import_aliases", {}).copy()
         self._native_modules = getattr(program, "native_modules", {})
+        self._native_functions = getattr(program, "native_functions", {})
         self._lines.clear()
         self._indent = 0
         self._runtime_emitted = False
@@ -1153,7 +1158,7 @@ class CodeGen:
                             break
             if imported_from:
                 mod_name = imported_from.replace("_", ".")
-                if self._native_modules.get(mod_name, False):
+                if self._native_modules.get(mod_name, False) or self._native_functions.get(fn_name, False):
                     mangled = fn_name
                 else:
                     mangled = f"{imported_from}_{fn_name}"

--- a/src/module_loader.py
+++ b/src/module_loader.py
@@ -137,6 +137,7 @@ def load_module(module_name: list[str], search_paths: list[str], loaded_modules:
                 for name, kind in mod_symbol.exports.items():
                     if kind == "function" and name in mod_symbol.functions:
                         checker.functions[name] = mod_symbol.functions[name]
+                        checker.native_functions[name] = mod_symbol.native_binding
                     else:
                         checker.env[name] = kind
             else:
@@ -155,6 +156,7 @@ def load_module(module_name: list[str], search_paths: list[str], loaded_modules:
                         kind = mod_symbol.exports[name]
                         if kind == "function" and name in mod_symbol.functions:
                             checker.functions[asname] = mod_symbol.functions[name]
+                            checker.native_functions[asname] = mod_symbol.native_binding
                         else:
                             checker.env[asname] = kind
                     else:

--- a/src/pb_pipeline.py
+++ b/src/pb_pipeline.py
@@ -49,6 +49,7 @@ def process_imports(ast: Program, pb_path: str, verbose: bool = False):
                 for name, kind in mod_symbol.exports.items():
                     if kind == "function" and name in mod_symbol.functions:
                         checker.functions[name] = mod_symbol.functions[name]
+                        checker.native_functions[name] = mod_symbol.native_binding
                     else:
                         checker.env[name] = kind
                 stmt.names = [ImportAlias(n) for n in mod_symbol.exports.keys()]
@@ -68,6 +69,7 @@ def process_imports(ast: Program, pb_path: str, verbose: bool = False):
                         kind = mod_symbol.exports[name]
                         if kind == "function" and name in mod_symbol.functions:
                             checker.functions[asname] = mod_symbol.functions[name]
+                            checker.native_functions[asname] = mod_symbol.native_binding
                         else:
                             checker.env[asname] = kind
                     else:

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -243,11 +243,14 @@ class TypeChecker:
             "__init__": (["Exception", "str"], "None", 2)
         }
         self.class_bases["Exception"] = None
-        
+
         for exc in ["RuntimeError", "ValueError", "IndexError", "TypeError"]:
             self.known_classes.add(exc)
             self.methods[exc] = {}  # no own methods
             self.class_bases[exc] = "Exception"
+
+        # Track whether a function was imported from a native module
+        self.native_functions: Dict[str, bool] = {}
 
     def _attr_full_name(self, expr: Expr) -> str | None:
         if isinstance(expr, Identifier):
@@ -280,6 +283,7 @@ class TypeChecker:
         program.import_aliases = {alias: mod.name for alias, mod in self.modules.items()}
         program.native_modules = {mod.name: mod.native_binding for mod in self.modules.values()}
         program.native_imports = {alias: mod.native_binding for alias, mod in self.modules.items()}
+        program.native_functions = dict(self.native_functions)
         return program
 
     def check_stmt(self, stmt: Stmt, parent: Stmt | None = None):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1100,6 +1100,16 @@ class TestCodeGenFromSource(unittest.TestCase):
         self.assertIn('int64_t x = arr.len;', c_code)
         self.assertIn('pb_print_int(x);', c_code)
 
+    def test_native_module_function_call_no_prefix(self):
+        code = (
+            "from raylib import InitWindow\n"
+            "def main() -> int:\n"
+            "    InitWindow(800, 600, \"Hello\")\n"
+            "    return 0\n"
+        )
+        header, c_code = self.compile_pipeline(code, pb_path="test.pb")
+        self.assertIn('InitWindow(800, 600, "Hello");', c_code)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- keep function calls to native module bindings unprefixed
- track native functions in typechecker and pipeline
- test calling functions from a native module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683b83085483218edccf89c980ba8d