### PR TITLE
Fix vendor paths resolved to absolute

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -240,10 +240,23 @@ def collect_vendor_build_info(loaded_modules):
     link_flags = set()
     for mod in loaded_modules.values():
         md = getattr(mod, "vendor_metadata", None)
-        if md:
-            include_dirs.update(md.get("include_dirs", []))
-            lib_dirs.update(md.get("lib_dirs", []))
-            link_flags.update(md.get("link_flags", []))
+        if not md:
+            continue
+
+        base_dir = os.path.dirname(getattr(mod, "path", ""))
+
+        for inc in md.get("include_dirs", []):
+            if not os.path.isabs(inc) and base_dir:
+                inc = os.path.abspath(os.path.join(base_dir, inc))
+            include_dirs.add(inc)
+
+        for lib in md.get("lib_dirs", []):
+            if not os.path.isabs(lib) and base_dir:
+                lib = os.path.abspath(os.path.join(base_dir, lib))
+            lib_dirs.add(lib)
+
+        link_flags.update(md.get("link_flags", []))
+
     return include_dirs, lib_dirs, link_flags
 
 

--- a/tests/test_vendor_absolute_paths.py
+++ b/tests/test_vendor_absolute_paths.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import json
+
+from module_loader import load_module
+from main import collect_vendor_build_info
+
+
+def create_module(tmpdir):
+    mod_dir = os.path.join(tmpdir, "vendor", "absmod")
+    os.makedirs(mod_dir, exist_ok=True)
+    pb_path = os.path.join(mod_dir, "absmod.pb")
+    with open(pb_path, "w") as f:
+        f.write("def f() -> int:\n    return 0\n")
+    metadata = {
+        "include_dirs": ["include"],
+        "lib_dirs": ["lib"],
+        "native": True
+    }
+    with open(os.path.join(mod_dir, "metadata.json"), "w") as f:
+        json.dump(metadata, f)
+    os.makedirs(os.path.join(mod_dir, "include"), exist_ok=True)
+    os.makedirs(os.path.join(mod_dir, "lib"), exist_ok=True)
+    return mod_dir
+
+
+def test_collect_vendor_build_info_returns_absolute_paths():
+    with tempfile.TemporaryDirectory() as tmp:
+        mod_dir = create_module(tmp)
+        loaded = {}
+        load_module(["absmod"], [mod_dir], loaded)
+        inc_dirs, lib_dirs, _ = collect_vendor_build_info(loaded)
+        inc_path = os.path.join(mod_dir, "include")
+        lib_path = os.path.join(mod_dir, "lib")
+        assert inc_path in inc_dirs
+        assert lib_path in lib_dirs
+        for p in inc_dirs.union(lib_dirs):
+            assert os.path.isabs(p)


### PR DESCRIPTION
## Summary
- resolve vendor include/lib dirs to absolute paths in `collect_vendor_build_info`
- add unit test ensuring absolute paths

## Testing
- `pytest -q`
- `pytest tests/test_vendor_absolute_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68683bf102a48321b35e6415eaed33c8