### PR TITLE
Improve iterable support in for loops

### DIFF
--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -362,6 +362,68 @@ class TestCodeGen(unittest.TestCase):
             "return 0;"
         ])
 
+    def test_for_loop_over_list_dict_set_str(self):
+        program = Program(body=[
+            FunctionDef(
+                name="main",
+                params=[],
+                return_type="int",
+                body=[
+                    VarDecl("nums", "list[int]", ListExpr(
+                        elements=[Literal("1"), Literal("2")],
+                        elem_type="int",
+                        inferred_type="list[int]"
+                    )),
+                    VarDecl("s", "str", StringLiteral(value="ab", inferred_type="str")),
+                    VarDecl("d", "dict[str, int]", DictExpr(
+                        keys=[StringLiteral("a")],
+                        values=[Literal("1")],
+                        elem_type="int",
+                        inferred_type="dict[str, int]"
+                    )),
+                    VarDecl("st", "set[int]", SetExpr(
+                        elements=[Literal("3")],
+                        elem_type="int",
+                        inferred_type="set[int]"
+                    )),
+                    ForStmt(
+                        var_name="n",
+                        iterable=Identifier("nums"),
+                        body=[ExprStmt(CallExpr(Identifier("print"), [Identifier("n")]))]
+                    ),
+                    ForStmt(
+                        var_name="ch",
+                        iterable=Identifier("s"),
+                        body=[ExprStmt(CallExpr(Identifier("print"), [Identifier("ch")]))]
+                    ),
+                    ForStmt(
+                        var_name="k",
+                        iterable=Identifier("d"),
+                        body=[ExprStmt(CallExpr(Identifier("print"), [Identifier("k")]))]
+                    ),
+                    ForStmt(
+                        var_name="x",
+                        iterable=Identifier("st"),
+                        body=[ExprStmt(CallExpr(Identifier("print"), [Identifier("x")]))]
+                    ),
+                    ReturnStmt(Literal("0"))
+                ],
+                globals_declared=None
+            )
+        ])
+        output = codegen_output(program)
+        assert_contains_all(self, output, [
+            "for (int64_t __i = 0; __i < nums.len; ++__i) {",
+            "int64_t n = nums.data[__i];",
+            "for (int64_t __i = 0; __i < strlen(s); ++__i) {",
+            "const char * ch = __tmp_char;",
+            "for (int64_t __i = 0; __i < d.len; ++__i) {",
+            "const char * k = d.data[__i].key;",
+            "for (int64_t __i = 0; __i < st.len; ++__i) {",
+            "int64_t x = st.data[__i];",
+            "return 0;"
+        ])
+
     def test_augmented_assignments(self):
         program = Program(body=[
             FunctionDef(

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -383,6 +383,36 @@ class TestTypeCheckerInternals(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.tc.check_for_stmt(stmt)
 
+    def test_for_loop_over_string(self):
+        stmt = ForStmt(
+            var_name="c",
+            iterable=Identifier("text"),
+            body=[PassStmt()]
+        )
+        self.tc.env["text"] = "str"
+        self.tc.check_for_stmt(stmt)
+        self.assertEqual(stmt.elem_type, "str")
+
+    def test_for_loop_over_dict(self):
+        stmt = ForStmt(
+            var_name="k",
+            iterable=Identifier("d"),
+            body=[PassStmt()]
+        )
+        self.tc.env["d"] = "dict[str, int]"
+        self.tc.check_for_stmt(stmt)
+        self.assertEqual(stmt.elem_type, "str")
+
+    def test_for_loop_over_set(self):
+        stmt = ForStmt(
+            var_name="x",
+            iterable=Identifier("s"),
+            body=[PassStmt()]
+        )
+        self.tc.env["s"] = "set[int]"
+        self.tc.check_for_stmt(stmt)
+        self.assertEqual(stmt.elem_type, "int")
+
     def test_class_def_simple(self):
         """
         class C:


### PR DESCRIPTION
## Summary
- support iterating over strings, sets and dicts in type checker
- generate loops for lists, sets, dicts and strings
- add tests for new for-loop behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d58157f48321a0cd8aa34df94a26