### PR TITLE
Add dynamic string concatenation

### DIFF
--- a/src/codegen.py
+++ b/src/codegen.py
@@ -1001,6 +1001,8 @@ class CodeGen:
         left  = self._expr(e.left)
         right = self._expr(e.right)
         op    = e.op
+        left_t = self._get_expr_type(e.left)
+        right_t = self._get_expr_type(e.right)
         # floor-div → C integer divide
         if op == "//":
             op = "/"
@@ -1013,6 +1015,8 @@ class CodeGen:
             return f"({left} == {right})"
         if op == "is not":
             return f"({left} != {right})"
+        if op == "+" and left_t == right_t == "str":
+            return f"pb_str_concat({left}, {right})"
         # default
         return f"({left} {op} {right})"
 

--- a/src/pb_runtime.c
+++ b/src/pb_runtime.c
@@ -49,6 +49,17 @@ const char *pb_format_int(int64_t x) {
     return bufs[i];
 }
 
+char *pb_str_concat(const char *a, const char *b) {
+    size_t len_a = strlen(a);
+    size_t len_b = strlen(b);
+    char *res = malloc(len_a + len_b + 1);
+    if (!res) pb_fail("Out of memory in pb_str_concat");
+    memcpy(res, a, len_a);
+    memcpy(res + len_a, b, len_b);
+    res[len_a + len_b] = '\0';
+    return res;
+}
+
 
 /* ------------ ERROR HANDLING ------------- */
 

--- a/src/pb_runtime.h
+++ b/src/pb_runtime.h
@@ -19,6 +19,7 @@ void pb_print_bool(bool b);
 
 const char *pb_format_double(double x);
 const char *pb_format_int(int64_t x);
+char *pb_str_concat(const char *a, const char *b);
 
 /* ------------ ERROR HANDLING ------------- */
 

--- a/src/type_checker.py
+++ b/src/type_checker.py
@@ -453,6 +453,9 @@ class TypeChecker:
 
             # Arithmetic
             if op in {"+", "-", "*", "/", "//", "%"}:
+                if op == "+" and left_type == right_type == "str":
+                    expr.inferred_type = "str"
+                    return "str"
                 if not is_numeric_type(left_type) or not is_numeric_type(right_type):
                     raise TypeError(f"Operator {op} not supported for types: {left_type} and {right_type}")
                 result_type = promote_numeric_types(left_type, right_type)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -214,6 +214,26 @@ class TestCodeGen(unittest.TestCase):
         self.assertIn('pb_print_str((snprintf(__fbuf, 256, "Hello, %s!", name), __fbuf));', output)
         self.assertIn('return 0;', output)
 
+    def test_string_concatenation(self):
+        prog = Program(body=[
+            FunctionDef(
+                name="main",
+                params=[],
+                return_type="int",
+                body=[
+                    VarDecl("a", "str", StringLiteral("foo")),
+                    VarDecl("b", "str", StringLiteral("bar")),
+                    VarDecl("c", "str", BinOp(Identifier("a"), "+", Identifier("b"))),
+                    ExprStmt(CallExpr(Identifier("print"), [Identifier("c")])),
+                    ReturnStmt(Literal("0"))
+                ],
+                globals_declared=None
+            )
+        ])
+        output = codegen_output(prog)
+        self.assertIn('const char * c = pb_str_concat(a, b);', output)
+        self.assertIn('pb_print_str(c);', output)
+
     def test_include_dotted_module_header(self):
         prog = Program(body=[
             ImportStmt(module=["pkg", "sub"])

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -751,6 +751,18 @@ class TestPipelineRuntime(unittest.TestCase):
         output = compile_and_run(code)
         self.assertEqual(output.strip(), "3")
 
+    def test_string_concat_runtime(self):
+        code = (
+            "def main() -> int:\n"
+            "    a: str = 'foo'\n"
+            "    b: str = 'bar'\n"
+            "    c: str = a + b\n"
+            "    print(c)\n"
+            "    return 0\n"
+        )
+        output = compile_and_run(code)
+        self.assertEqual(output.strip(), "foobar")
+
     def test_numeric_literal_underscores_runtime(self):
         code = (
             "def main() -> int:\n"


### PR DESCRIPTION
## Summary
- allow `+` operator for `str` in type checker
- generate calls to `pb_str_concat` for string addition
- implement `pb_str_concat` runtime helper
- test concatenation in codegen and runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a73df5648321b58a04050478cb6d