### PR TITLE
Implement list memory cleanup

### DIFF
--- a/ref/ref_lang.c
+++ b/ref/ref_lang.c
@@ -359,4 +359,7 @@ int main(void)
     Mage__heal(mage, 40);
     pb_print_str((snprintf(__fbuf, 256, "HP after healing: %lld", mage->base.hp), __fbuf));
     pb_print_str((snprintf(__fbuf, 256, "MP after healing: %lld", mage->mp), __fbuf));
+    list_int_free(&arr_int_empty);
+    list_str_free(&arr_str_empty);
+    list_bool_free(&arr_bool_empty);
 }


### PR DESCRIPTION
## Summary
- track heap-allocated list variables during code generation
- emit `list_*_free` calls before returning from functions and at end of `main`
- update reference C output to include cleanup lines

## Testing
- `pytest -q`
- `pytest tests/test_pipeline.py::TestCodeGenFromSource::test_lang_pb_codegen_matches_expected -q`


------
https://chatgpt.com/codex/tasks/task_e_685d2257eb8083219f19d2eb649171b3